### PR TITLE
remove source map files references in packed files

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "lint": "tslint index.ts lib/**/*.ts test/**/*.ts --exclude '**/*.d.ts'",
     "build": "tsc",
     "validate": "npm ls",
-    "prepare": "npm run build",
+    "prepare": "tsc --sourceMap false --inlineSources false --inlineSourceMap false",
     "version": "manual-git-changelog onversion"
   }
 }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "lint": "tslint index.ts lib/**/*.ts test/**/*.ts --exclude '**/*.d.ts'",
     "build": "tsc",
     "validate": "npm ls",
-    "prepare": "tsc --sourceMap false --inlineSources false --inlineSourceMap false",
+    "prepare": "npm run build",
     "version": "manual-git-changelog onversion"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
   "license": "MIT",
   "files": [
     "lib/**/*.d.ts",
+    "lib/**/*.js.map",
     "lib/**/*.js",
     "index.d.ts",
+    "index.js.map",
     "index.js"
   ],
   "dependencies": {


### PR DESCRIPTION
Thanks for the library! It saved me from implementing my own parser for RDF strings. But there is a problem with its usage with webpack. Please see the description below.

Before the change, packaged files include the reference to their map file.
For example, generated index.js file has the following line at the end:
```
//# sourceMappingURL=index.js.map
```
react-scripts (webpack under the hood) produce warnings in the build:
```
Failed to parse source map from 'XXX/node_modules/rdf-string/index.js.map'
file: Error: ENOENT: no such file or directory, open
'XXX/node_modules/rdf-string/index.js.map'

Failed to parse source map from 'XXX/node_modules/rdf-string/lib/TermUtil.js.map'
file: Error: ENOENT: no such file or directory, open
'XXX/node_modules/rdf-string/lib/TermUtil.js.map'
```
Warnings are legit because map files aren't included in the package. I assume
it's the original intention. To avoid the warning and prevent webpack warnings
I removed sourcemap files generation and their inclusion in "prepare" script
that is launched only before "publish" or "pack" lifecycles.

Also, the same warnings are included in `rdf-data-factory` package. If you agree with these changes I would create a similar PR in rdf-data-factory repo too.